### PR TITLE
Fixed behaviour for passing back array with changed files

### DIFF
--- a/lib/replaceInFile.js
+++ b/lib/replaceInFile.js
@@ -58,7 +58,7 @@ module.exports = function replaceInFile(config, cb) {
       }
       processedFiles++;
       if (processedFiles === totalFiles) {
-        cb(null, [changedFiles]);
+        cb(null, changedFiles);
       }
     });
   });


### PR DESCRIPTION
When using this module, I noticed that the array including the changed files was passed back inside another array. I didn't really find out any use for this, perhaps this was just a typo?